### PR TITLE
KMS should for mainnet api keys force using of 4-eyes-principle

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ If you want to verify, if transaction, which is being signed using KMS is yours,
 Add `externalUrl` parameter, which will point to your application server. This server will hold list of valid
 transactions to sign. Every time the tx is fetched from Tatum to be signed, it is validated against the external server
 using simple HTTP GET operation `your_external_url/transaction_id`. If response is 2xx, transaction is being signed.
-Otherwise transaction is skipped and not signed and you should do the appropriate operations on your end.
+Otherwise transaction is skipped and not signed and you should do the appropriate operations on your end. This parameter
+is mandatory for mainnet, to increase security on production environment. 
 
 ```
 tatum-kms daemon --external-url=http://192.168.57.63

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum-kms",
-  "version": "4.0",
+  "version": "4.0.0",
   "description": "Tatum KMS - Key Management System for Tatum-powered apps.",
   "main": "dist/index.js",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum-kms",
-  "version": "3.5.3",
+  "version": "4.0",
   "description": "Tatum KMS - Key Management System for Tatum-powered apps.",
   "main": "dist/index.js",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ const { input: command, flags } = meow(`
         --chain                           Blockchains to check, separated by comma. Daemon mode only.
 	    --vgs                             Using VGS (https://verygoodsecurity.com) as a secure storage of the password which unlocks the wallet file.
 	    --azure                           Using Azure Vault (https://azure.microsoft.com/en-us/services/key-vault/) as a secure storage of the password which unlocks the wallet file.
-        --externalUrl                    Pass in external url to check valid transaction
+        --externalUrl                     Pass in external url to check valid transaction. This parameter is mandatory for mainnet (if testnet is false).  Daemon mode only.
 `, {
     flags: {
         path: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,7 +77,8 @@ const { input: command, flags } = meow(`
             default: 5,
         },
         externalUrl: {
-            type: 'string'
+            type: 'string',
+            isRequired: (flags, input) => input[0] === 'daemon' && !flags.testnet
         }
     }
 });


### PR DESCRIPTION
Setted up externalUrl parameter as mandatory for mainnet.