### PR TITLE
Fix docker vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine3.12 AS builder
+FROM node:14-alpine3.16 AS builder
 
 # Create app directory
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum-kms",
-  "version": "4.1.5",
+  "version": "4.1.6",
   "description": "Tatum KMS - Key Management System for Tatum-powered apps.",
   "main": "dist/index.js",
   "engines": {


### PR DESCRIPTION
**With current alpine version**

snyk container test node:14-alpine3.12

Testing node:14-alpine3.12...

✗ Low severity vulnerability found in busybox/busybox
  Description: ALPINE-13661
  Info: https://security.snyk.io/vuln/SNYK-ALPINE312-BUSYBOX-2606933
  Introduced through: busybox/busybox@1.31.1-r21, alpine-baselayout/alpine-baselayout@3.2.0-r7, busybox/ssl_client@1.31.1-r21
  From: busybox/busybox@1.31.1-r21
  From: alpine-baselayout/alpine-baselayout@3.2.0-r7 > busybox/busybox@1.31.1-r21
  From: busybox/ssl_client@1.31.1-r21
  Image layer: Introduced by your base image (node:14.18.2-alpine3.12)
  Fixed in: 1.31.1-r22

✗ High severity vulnerability found in zlib/zlib
  Description: Out-of-bounds Write
  Info: https://security.snyk.io/vuln/SNYK-ALPINE312-ZLIB-2434421
  Introduced through: zlib/zlib@1.2.11-r3, apk-tools/apk-tools@2.10.8-r0
  From: zlib/zlib@1.2.11-r3
  From: apk-tools/apk-tools@2.10.8-r0 > zlib/zlib@1.2.11-r3
  Image layer: Introduced by your base image (node:14.18.2-alpine3.12)
  Fixed in: 1.2.12-r0

✗ High severity vulnerability found in openssl/libcrypto1.1
  Description: Loop with Unreachable Exit Condition ('Infinite Loop')
  Info: https://security.snyk.io/vuln/SNYK-ALPINE312-OPENSSL-2426332
  Introduced through: openssl/libcrypto1.1@1.1.1l-r0, openssl/libssl1.1@1.1.1l-r0, apk-tools/apk-tools@2.10.8-r0, libtls-standalone/libtls-standalone@2.9.1-r1
  From: openssl/libcrypto1.1@1.1.1l-r0
  From: openssl/libssl1.1@1.1.1l-r0 > openssl/libcrypto1.1@1.1.1l-r0
  From: apk-tools/apk-tools@2.10.8-r0 > openssl/libcrypto1.1@1.1.1l-r0
  and 4 more...
  Image layer: Introduced by your base image (node:14.18.2-alpine3.12)
  Fixed in: 1.1.1n-r0

✗ Critical severity vulnerability found in busybox/busybox
  Description: CVE-2022-28391
  Info: https://security.snyk.io/vuln/SNYK-ALPINE312-BUSYBOX-2440610
  Introduced through: busybox/busybox@1.31.1-r21, alpine-baselayout/alpine-baselayout@3.2.0-r7, busybox/ssl_client@1.31.1-r21
  From: busybox/busybox@1.31.1-r21
  From: alpine-baselayout/alpine-baselayout@3.2.0-r7 > busybox/busybox@1.31.1-r21
  From: busybox/ssl_client@1.31.1-r21
  Image layer: Introduced by your base image (node:14.18.2-alpine3.12)
  Fixed in: 1.31.1-r22
  
  **With updated snyk version, security report is ok:**
  snyk container test node:14-alpine3.16

Testing node:14-alpine3.16...

Organization:      lukas.kotol
Package manager:   apk
Project name:      docker-image|node
Docker image:      node:14-alpine3.16
Platform:          linux/amd64
Base image:        node:14.20.0-alpine3.16
Licenses:          enabled

✔ Tested 16 dependencies for known issues, no vulnerable paths found.

Base Image               Vulnerabilities  Severity
node:14.20.0-alpine3.16  1                0 critical, 1 high, 0 medium, 0 low

Recommendations for base image upgrade:

Alternative image types
Base Image                  Vulnerabilities  Severity
node:16.16.0-bullseye-slim  43               0 critical, 0 high, 0 medium, 43 low
node:18.6.0-slim            43               0 critical, 0 high, 0 medium, 43 low

