### PR TITLE
Fix a bug in signing XRP and XLM transactions in imported wallets.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/tatum-kms",
-  "version": "6.3.0",
+  "version": "6.3.1",
   "description": "Tatum KMS - Key Management System for Tatum-powered apps.",
   "main": "dist/index.js",
   "engines": {

--- a/src/signatures.ts
+++ b/src/signatures.ts
@@ -194,13 +194,15 @@ const processTransaction = async (
     }
     case Currency.XRP: {
       const xrpSdk = TatumXrpSDK({ apiKey: process.env.TATUM_API_KEY as string, url: TATUM_URL as any })
-      txData = await xrpSdk.kms.sign(blockchainSignature as PendingTransaction, wallets[0].secret)
+      const xrpSecret = wallets[0].secret ? wallets[0].secret : wallets[0].privateKey;
+      txData = await xrpSdk.kms.sign(blockchainSignature, xrpSecret);
       await xrpSdk.blockchain.broadcast({ txData, signatureId: blockchainSignature.id })
       return
     }
     case Currency.XLM: {
       const xlmSdk = TatumXlmSDK({ apiKey: process.env.TATUM_API_KEY as string, url: TATUM_URL as any })
-      txData = await xlmSdk.kms.sign(blockchainSignature as PendingTransaction, wallets[0].secret, testnet)
+      const xlmSecret = wallets[0].secret ? wallets[0].secret : wallets[0].privateKey;
+      txData = await xlmSdk.kms.sign(blockchainSignature, xlmSecret, testnet);
       await xlmSdk.blockchain.broadcast({ txData, signatureId: blockchainSignature.id })
       return
     }


### PR DESCRIPTION
If you import your XRP/XLM wallet, there is no secret property and you should use privateKey instead, so Both these properties must be checked, exactly like the ALGO.