### PR TITLE
Adding runOnce and validationMethod and bug fix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import { Currency, generateWallet } from '@tatumio/tatum'
 import axios from 'axios'
 import dotenv from 'dotenv'
 import meow from 'meow'
-import { PasswordType } from './interfaces'
+import { ExternalUrlMethod, PasswordType } from './interfaces'
 import {
   checkConfig,
   exportWallets,
@@ -70,6 +70,8 @@ const { input: command, flags, help } = meow(
 	      --vgs                             Using VGS (https://verygoodsecurity.com) as a secure storage of the password which unlocks the wallet file.
         --azure                           Using Azure Vault (https://azure.microsoft.com/en-us/services/key-vault/) as a secure storage of the password which unlocks the wallet file.
         --externalUrl                     Pass in external url to check valid transaction. This parameter is mandatory for mainnet (if testnet is false).  Daemon mode only.
+        --externalUrlMethod               Determine what http method to use when calling the url passed in the --externalUrl option. Accepts GET or POST. Defaults to GET method. Daemon mode only. 
+        --runOnce                         Run the daemon command one time. Check for a new transactions to sign once, and then exit the process. Daemon mode only.
 `,
   {
     flags: {
@@ -106,6 +108,14 @@ const { input: command, flags, help } = meow(
       'env-file': {
         type: 'string',
       },
+      externalUrlMethod: {
+        type: 'string',
+        default: 'GET',
+      },
+      runOnce: {
+        type: 'boolean',
+        default: false,
+      }
     },
   },
 )
@@ -145,7 +155,9 @@ const startup = async () => {
         flags.path,
         flags.chain?.split(',') as Currency[],
         flags.externalUrl,
+        flags.externalUrlMethod as ExternalUrlMethod,
         flags.period,
+        flags.runOnce,
       )
       break
     }

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -28,3 +28,5 @@ export interface StoreWalletValue {
   address?: string
   xpub?: string
 }
+
+export type ExternalUrlMethod = 'GET' | 'POST';

--- a/src/management.ts
+++ b/src/management.ts
@@ -87,7 +87,7 @@ export const getPassword = async (pwdType: PasswordType, axiosInstance: AxiosIns
   }
 }
 
-export const exportWallets = (pwd: string, _path1: string | undefined, path?: string) => {
+export const exportWallets = (pwd: string, path?: string) => {
   const pathToWallet = path || homedir() + '/.tatumrc/wallet.dat'
   if (!existsSync(pathToWallet)) {
     console.error(JSON.stringify({ error: `No such wallet file.` }, null, 2))


### PR DESCRIPTION
adding two flags to the `daemon` command:
runOnce - for fetching pending transactions one time, and not in a period loop. This allows more control on the user side.
externalUrlMethod - accepts 'POST' or 'GET'. If POST is past then the `externalUrl` will be called using HTTP POST method, and will pass the transaction details in the body of the request.

Another change, is for what seems to be a bug in the `export` command where the `path` past in the command is ignored. 